### PR TITLE
Update caido download links

### DIFF
--- a/home/programs/caido/cli_pkg.nix
+++ b/home/programs/caido/cli_pkg.nix
@@ -8,7 +8,7 @@ with pkgs;
     inherit version;
 
     src = fetchurl {
-      url = "https://storage.googleapis.com/caido-releases/v${version}/caido-cli-v${version}-linux-x86_64.tar.gz";
+      url = "https://caido.download/releases/v${version}/caido-cli-v${version}-linux-x86_64.tar.gz";
       hash = "sha256-I8UF2rzIKfpcrxyvDa4AReWDIHOKTCj3ERaWhG1xGG0=";
     };
 


### PR DESCRIPTION
Hi! Creator of Caido here.
We are moving away from GCP and onto our own download domain.
Older links won't work within the next 30 days.
Documentation: https://docs.caido.io/concepts/internals/download.html